### PR TITLE
Add optional sql query parameter to allow SQL to be executed against …

### DIFF
--- a/beam_nuggets/io/test/test_read_transform.py
+++ b/beam_nuggets/io/test/test_read_transform.py
@@ -28,6 +28,18 @@ class TestReadTransform(TransformBaseTest):
                 equal_to(self.table_rows)
             )
 
+    def test_QueryFromRelationalDB(self):
+        # create a read pipeline with a SQL query, execute it and compare retrieved to actual rows
+        with TestPipeline() as p:
+            assert_that(
+                p | "Reading records from db" >> relational_db.Read(
+                    source_config=self.source_config,
+                    table_name=self.table_name,
+                    query='select * from ' + self.table_name
+                ),
+                equal_to(self.table_rows)
+            )
+
     def create_and_populate_test_table(self, n_rows=10):
         # test table schema and data
         table_name = 'students'
@@ -61,3 +73,4 @@ class TestReadTransform(TransformBaseTest):
 
 if __name__ == '__main__':
     unittest.main()
+


### PR DESCRIPTION
I came across the same use case as issue #17 where I needed to query against a table in my Apache Beam pipeline. This solution adds a query parameter to the Read class that allows data to be returned in the same form as when querying a whole table. The query parameter is used to specify the columns returned.