### PR TITLE
Add python3 compatibility iterator for `iteritems`.

### DIFF
--- a/beam_nuggets/compat.py
+++ b/beam_nuggets/compat.py
@@ -1,0 +1,10 @@
+try:
+    dict.iteritems
+except AttributeError:
+    # Python 3
+    def iteritems(d):
+        return iter(d.items())
+else:
+    # Python 2
+    def iteritems(d):
+        return d.iteritems()

--- a/beam_nuggets/io/relational_db_api.py
+++ b/beam_nuggets/io/relational_db_api.py
@@ -3,6 +3,7 @@ from __future__ import division, print_function
 
 import datetime
 
+from beam_nuggets.compat import iteritems
 from sqlalchemy import (
     create_engine, MetaData, Table, Column,
     Integer,
@@ -454,7 +455,7 @@ def _columns_from_sample_record(record, primary_key_column_names, drivername):
         ]
         other_columns = [
             Column(col, infer_db_type(value, drivername))
-            for col, value in record.iteritems()
+            for col, value in iteritems(record)
             if col not in primary_key_column_names
         ]
     else:
@@ -464,7 +465,7 @@ def _columns_from_sample_record(record, primary_key_column_names, drivername):
         primary_key_columns = [Column(pri_col_name, Integer, primary_key=True)]
         other_columns = [
             Column(col, infer_db_type(value, drivername))
-            for col, value in record.iteritems()
+            for col, value in iteritems(record)
         ]
     return primary_key_columns + other_columns
 

--- a/beam_nuggets/transforms/json_.py
+++ b/beam_nuggets/transforms/json_.py
@@ -3,6 +3,7 @@ from __future__ import division, print_function
 import json
 
 import apache_beam as beam
+from beam_nuggets.compat import iteritems
 
 
 class ParseJson(beam.DoFn):
@@ -18,5 +19,5 @@ class ParseJson(beam.DoFn):
         """
         yield {
             k: json.loads(v) if k in self.only_keys else v
-            for k, v in element.iteritems()
+            for k, v in iteritems(element)
         }


### PR DESCRIPTION
Without these compatibility options beam_nuggets will fail if executed
with Python3.

The compatibility implementation is based on PEP-469. https://www.python.org/dev/peps/pep-0469/

I took the creative liberty to put an extra compat module for this code.

I noticed it was failing for me while it was preparing the auto schema for a postgresql db.

I also considered to use the python3 syntax, but the SDK for beam lists python2.7 as supported for now.