### PR TITLE
Added ability to specify custom decoder to KafkaConsumer

### DIFF
--- a/beam_nuggets/io/kafkaio.py
+++ b/beam_nuggets/io/kafkaio.py
@@ -62,11 +62,12 @@ class _ConsumeKafkaTopic(DoFn):
     def process(self, config):
         consumer_config = dict(config)
         topic = consumer_config.pop('topic')
+        value_decoder = consumer_config.pop('value_decoder', bytes.decode)
         consumer = KafkaConsumer(topic, **consumer_config)
 
         for msg in consumer:
             try:
-                yield (msg.key, msg.value.decode())
+                yield (msg.key, value_decoder(msg.value))
             except Exception as e:
                 print(e)
                 continue


### PR DESCRIPTION
Addresses issue [33](https://github.com/mohaseeb/beam-nuggets/issues/33)

This PR adds the ability for a user to specify a decoder for the KafkaConsume DoFn, and hence not be restricted to only utf-8 encoded messages.